### PR TITLE
Refactor Eater and GenericMerge contracts

### DIFF
--- a/contracts/core/merge/Eater.sol
+++ b/contracts/core/merge/Eater.sol
@@ -17,6 +17,7 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
     uint256 internal _rate;
     address internal _token;
     address public wewe;
+    uint256 public minAmount;
 
     uint8 internal vestingDuration;
     mapping(address => Vesting) public vestings;
@@ -56,6 +57,10 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
         emit Merged(amount, from);
     }
 
+    function setMinAmount(uint256 amount) external onlyOwner {
+        minAmount = amount;
+    }
+
     function sweep() external onlyOwner {
         uint256 balance = IERC20(wewe).balanceOf(address(this));
         require(balance > 0, "Eater: No balance to sweep");
@@ -91,6 +96,11 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
         }
 
         require(vestings[account].end <= block.timestamp, "Eater: Vesting not ended");
+        _;
+    }
+
+    modifier whenSolvent() {
+        require(IERC20(wewe).balanceOf(address(this)) >= minAmount, "Eater: Insufficient Wewe balance");
         _;
     }
 

--- a/contracts/core/merge/Eater.sol
+++ b/contracts/core/merge/Eater.sol
@@ -104,7 +104,7 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
 
     modifier whenSolvent() {
         require(IERC20(wewe).balanceOf(address(this)) >= minAmount, "Eater: Insufficient Wewe balance");
-
+        require(IERC20(wewe).balanceOf(address(this)) >= _sumOfVested, "Eater: Insufficient token balance");
         _;
     }
 

--- a/contracts/core/merge/Eater.sol
+++ b/contracts/core/merge/Eater.sol
@@ -18,8 +18,9 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
     address internal _token;
     address public wewe;
     uint256 public minAmount;
+    uint256 internal _sumOfVested;
 
-    uint8 internal vestingDuration;
+    uint8 public vestingDuration;
     mapping(address => Vesting) public vestings;
 
     function _setRate(uint256 rate) internal {
@@ -33,6 +34,8 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
 
     function _merge(uint256 amount, address token, address from) internal {
         uint256 weweToTransfer = (amount * _rate) / 100000;
+        _sumOfVested += weweToTransfer;
+
         require(
             weweToTransfer <= IERC20(wewe).balanceOf(address(this)),
             "Eater: Insufficient token balance to transfer"
@@ -101,6 +104,7 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
 
     modifier whenSolvent() {
         require(IERC20(wewe).balanceOf(address(this)) >= minAmount, "Eater: Insufficient Wewe balance");
+
         _;
     }
 

--- a/contracts/core/merge/Eater.sol
+++ b/contracts/core/merge/Eater.sol
@@ -104,7 +104,7 @@ abstract contract Eater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
 
     modifier whenSolvent() {
         require(IERC20(wewe).balanceOf(address(this)) >= minAmount, "Eater: Insufficient Wewe balance");
-        require(IERC20(wewe).balanceOf(address(this)) >= _sumOfVested, "Eater: Insufficient token balance");
+        require(IERC20(wewe).balanceOf(address(this)) >= _sumOfVested, "Eater: Insufficient Wewe balance");
         _;
     }
 

--- a/contracts/core/merge/GenericMerge.sol
+++ b/contracts/core/merge/GenericMerge.sol
@@ -34,12 +34,12 @@ contract GenericMerge is Eater, IMergeV2 {
         _setRate(rate);
     }
 
-    function mergeAll() external virtual whenNotPaused {
+    function mergeAll() external virtual whenNotPaused whenSolvent {
         uint256 balance = IERC20(_token).balanceOf(msg.sender);
         _merge(balance, _token, msg.sender);
     }
 
-    function merge(uint256 amount) external virtual whenNotPaused {
+    function merge(uint256 amount) external virtual whenNotPaused whenSolvent {
         uint256 balance = IERC20(_token).balanceOf(msg.sender);
         require(balance >= amount, "GenericMerge: Insufficient balance to eat");
 

--- a/contracts/core/merge/GenericMerge.sol
+++ b/contracts/core/merge/GenericMerge.sol
@@ -48,6 +48,7 @@ contract GenericMerge is Eater, IMergeV2 {
 
     function claim() external whenNotPaused whenClaimable(msg.sender) {
         uint256 amount = vestings[msg.sender].amount;
+        _sumOfVested -= amount;
         vestings[msg.sender].amount = 0;
 
         IERC20(wewe).transfer(msg.sender, amount);

--- a/contracts/core/merge/GenericMerge.sol
+++ b/contracts/core/merge/GenericMerge.sol
@@ -7,7 +7,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract GenericMerge is Eater, IMergeV2 {
-    constructor(address _wewe, address token, uint8 _vestingDuration) {
+    constructor(address _wewe, address token, uint32 _vestingDuration) {
         _rate = 100;
         wewe = _wewe;
         _token = token;
@@ -34,12 +34,7 @@ contract GenericMerge is Eater, IMergeV2 {
         _setRate(rate);
     }
 
-    function mergeAll() external virtual whenNotPaused whenSolvent {
-        uint256 balance = IERC20(_token).balanceOf(msg.sender);
-        _merge(balance, _token, msg.sender);
-    }
-
-    function merge(uint256 amount) external virtual whenNotPaused whenSolvent {
+    function merge(uint256 amount) external virtual whenNotPaused whenSolvent(amount) {
         uint256 balance = IERC20(_token).balanceOf(msg.sender);
         require(balance >= amount, "GenericMerge: Insufficient balance to eat");
 
@@ -48,7 +43,7 @@ contract GenericMerge is Eater, IMergeV2 {
 
     function claim() external whenNotPaused whenClaimable(msg.sender) {
         uint256 amount = vestings[msg.sender].amount;
-        _sumOfVested -= amount;
+        sumOfVested -= amount;
         vestings[msg.sender].amount = 0;
 
         IERC20(wewe).transfer(msg.sender, amount);

--- a/contracts/core/merge/MergeFactory.sol
+++ b/contracts/core/merge/MergeFactory.sol
@@ -29,7 +29,7 @@ contract MergeFactory is Ownable {
         return tokens.length;
     }
 
-    function createMerge(address token, uint256 rate, uint8 vestingDuration) external onlyDeployer returns (address) {
+    function createMerge(address token, uint256 rate, uint32 vestingDuration) external onlyDeployer returns (address) {
         require(merges[token] == address(0), "MergeFactory: Merge already exists");
         address merge = address(new MergeWithMarket(token, wewe, vestingDuration));
         IMergeV2(merge).setRate(rate);
@@ -40,7 +40,7 @@ contract MergeFactory is Ownable {
     function createMergeWithType(
         address token,
         uint256 rate,
-        uint8 vestingDuration,
+        uint32 vestingDuration,
         MergeType mergeType
     ) external onlyDeployer returns (address) {
         require(merges[token] == address(0), "MergeFactory: Merge already exists");

--- a/contracts/core/merge/MergeWithMarket.sol
+++ b/contracts/core/merge/MergeWithMarket.sol
@@ -8,14 +8,10 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract MergeWithMarket is GenericMerge {
     address public treasury;
 
-    constructor(address _wewe, address token, uint8 _vestingDuration) GenericMerge(_wewe, token, _vestingDuration) {}
+    constructor(address _wewe, address token, uint32 _vestingDuration) GenericMerge(_wewe, token, _vestingDuration) {}
 
     function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
-    }
-
-    function mergeAll() external override whenNotPaused {
-        revert("Function disabled");
     }
 
     function merge(uint256 amount) external override whenNotPaused {
@@ -26,7 +22,7 @@ contract MergeWithMarket is GenericMerge {
         uint256 amount,
         IAMM amm,
         bytes calldata extraData
-    ) external nonReentrant whenNotPaused whenSolvent {
+    ) external nonReentrant whenNotPaused whenSolvent(amount) {
         uint256 balance = IERC20(_token).balanceOf(msg.sender);
         require(balance >= amount, "MergeWithMarket: Insufficient balance to eat");
 

--- a/contracts/core/merge/MergeWithMarket.sol
+++ b/contracts/core/merge/MergeWithMarket.sol
@@ -22,7 +22,11 @@ contract MergeWithMarket is GenericMerge {
         revert("Function disabled");
     }
 
-    function mergeAndSell(uint256 amount, IAMM amm, bytes calldata extraData) external nonReentrant {
+    function mergeAndSell(
+        uint256 amount,
+        IAMM amm,
+        bytes calldata extraData
+    ) external nonReentrant whenNotPaused whenSolvent {
         uint256 balance = IERC20(_token).balanceOf(msg.sender);
         require(balance >= amount, "MergeWithMarket: Insufficient balance to eat");
 

--- a/contracts/interfaces/IMergeV2.sol
+++ b/contracts/interfaces/IMergeV2.sol
@@ -7,5 +7,4 @@ interface IMergeV2 {
     function setRate(uint256 rate) external;
     function getToken() external view returns (address);
     function merge(uint256 amount) external;
-    function mergeAll() external;
 }


### PR DESCRIPTION
- Add public variable `minAmount` to Eater contract
- Implement `setMinAmount` function in Eater contract
- Add `whenSolvent` modifier to Eater contract
- Modify `mergeAll` and `merge` functions in GenericMerge contract to include `whenSolvent` modifier
- Add `whenSolvent` modifier to `mergeAndSell` function in MergeWithMarket contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a minimum balance requirement for Wewe tokens through a new public state variable `minAmount`.
	- Added functionality for the contract owner to set the minimum amount with `setMinAmount`.
	- Implemented a new modifier `whenSolvent` to enforce balance checks before executing certain functions.
	- Enhanced tracking of vested tokens with the new `sumOfVested` variable.
	- Added a public function `setVestingDuration` for the contract owner to adjust the vesting period.
	- Updated the constructor to accept a larger range for `vestingDuration`.

- **Bug Fixes**
	- Removed the `mergeAll` function to streamline available operations.
	- Updated function signatures for `merge` and `mergeAndSell` to include the `whenSolvent` modifier, ensuring proper execution conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->