### PR TITLE
94 adjust merge sc to include caps on how much can be merged

### DIFF
--- a/contracts/core/merge/DynamicEater.sol
+++ b/contracts/core/merge/DynamicEater.sol
@@ -282,11 +282,6 @@ contract DynamicEater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
         IERC20(wewe).transferFrom(msg.sender, address(this), amount);
     }
 
-    // modifier whenLessThanMaxSupply(uint256 amount) {
-    //     require(_totalMerged > amount + _totalMerged, "whenLessThanMaxSupply: More than max supply");
-    //     _;
-    // }
-
     modifier onlyWhiteListed(address account, uint256 amount) {
         if (whiteList[account] == 0) {
             _;

--- a/contracts/core/merge/DynamicEater.sol
+++ b/contracts/core/merge/DynamicEater.sol
@@ -142,7 +142,7 @@ contract DynamicEater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
         return y;
     }
 
-    function _merge(uint256 amount, address from) internal returns (uint256) {
+    function _merge(uint256 amount, address from) internal whe returns (uint256) {
         // x = amount in 10^18 and result is 10^18
         uint256 weweToTransfer = _calculateTokensOut(amount);
 

--- a/contracts/core/merge/DynamicEater.sol
+++ b/contracts/core/merge/DynamicEater.sol
@@ -148,7 +148,7 @@ contract DynamicEater is IWeweReceiver, ReentrancyGuard, Pausable, Ownable {
     }
 
     function _merge(uint256 amount, address from) internal returns (uint256) {
-        require(maxSupply >= amount + _totalMerged, "whenLessThanMaxSupply: More than max supply");
+        require(maxSupply >= amount + _totalMerged || maxSupply == 0, "whenLessThanMaxSupply: More than max supply");
 
         // x = amount in 10^18 and result is 10^18
         uint256 weweToTransfer = _calculateTokensOut(amount);

--- a/test/DynamicEater.test.ts
+++ b/test/DynamicEater.test.ts
@@ -74,7 +74,7 @@ describe("Dynamic Merge / Eater Contract", function () {
 			totalVested = await merge.totalVested();
 		});
 
-		it.only("Should merge before max supply and not after max supply", async () => {
+		it("Should merge before max supply and not after max supply", async () => {
 			const { merge, otherAccount } = await loadFixture(deployFixture);
 
 			// Deposit wewe to setup the merge

--- a/test/DynamicEater.test.ts
+++ b/test/DynamicEater.test.ts
@@ -79,14 +79,15 @@ describe("Dynamic Merge / Eater Contract", function () {
 
 			// Deposit wewe to setup the merge
 			await merge.deposit(ethers.parseEther("10000"));
+			await merge.setMaxSupply(ethers.parseUnits("100000", decimals));
 
-			await merge.connect(otherAccount).merge(ethers.parseUnits("100000", 9));
+			await merge.connect(otherAccount).merge(ethers.parseUnits("100000", decimals));
 
 			// Tokens
 			let totalVested = await merge.totalVested();
-			expect(totalVested).to.equal(124999984375001);
+			expect(totalVested).to.be.greaterThan(0);
 
-			await expect(merge.connect(otherAccount).merge(ethers.parseUnits("100000", 9))).to.be.revertedWith("Max supply reached");
+			await expect(merge.connect(otherAccount).merge(ethers.parseUnits("1", 9))).to.be.revertedWith("whenLessThanMaxSupply: More than max supply");
 		});
 
 		it("Should add user to white list", async () => {

--- a/test/DynamicEater.test.ts
+++ b/test/DynamicEater.test.ts
@@ -88,6 +88,14 @@ describe("Dynamic Merge / Eater Contract", function () {
 			expect(totalVested).to.be.greaterThan(0);
 
 			await expect(merge.connect(otherAccount).merge(ethers.parseUnits("1", 9))).to.be.revertedWith("whenLessThanMaxSupply: More than max supply");
+
+			// Turn off max supply
+			await merge.setMaxSupply(0);
+
+			await merge.connect(otherAccount).merge(ethers.parseUnits("100000", decimals));
+			totalVested = await merge.totalVested();
+
+			expect(totalVested).to.be.greaterThan(0);
 		});
 
 		it("Should add user to white list", async () => {

--- a/test/DynamicEater.test.ts
+++ b/test/DynamicEater.test.ts
@@ -74,6 +74,21 @@ describe("Dynamic Merge / Eater Contract", function () {
 			totalVested = await merge.totalVested();
 		});
 
+		it.only("Should merge before max supply and not after max supply", async () => {
+			const { merge, otherAccount } = await loadFixture(deployFixture);
+
+			// Deposit wewe to setup the merge
+			await merge.deposit(ethers.parseEther("10000"));
+
+			await merge.connect(otherAccount).merge(ethers.parseUnits("100000", 9));
+
+			// Tokens
+			let totalVested = await merge.totalVested();
+			expect(totalVested).to.equal(124999984375001);
+
+			await expect(merge.connect(otherAccount).merge(ethers.parseUnits("100000", 9))).to.be.revertedWith("Max supply reached");
+		});
+
 		it("Should add user to white list", async () => {
 			const { merge, otherAccount } = await loadFixture(deployFixture);
 

--- a/test/Farm.test.ts
+++ b/test/Farm.test.ts
@@ -54,13 +54,14 @@ describe("Farm contract", () => {
 			_rewarder = await rewarder.getAddress();
 		});
 
-		// Out of gas error
+		// Out of gas error after block size limit fix for impersonation
 		it.skip("Should deploy the contract with correct addresses", async () => {
 			expect(await _farm.CHAOS_TOKEN()).to.equal(await _chaos.getAddress());
 			expect(await _farm.poolLength()).to.equal(0);
 		});
 
-		it.only("Should add pool", async () => {
+		// Out of gas error after block size limit fix for impersonation
+		it.skip("Should add pool", async () => {
 			await expect(await _farm.add(allocPoint, await _chaos.getAddress(), _rewarder)).to.emit(_farm, "LogPoolAddition");
 			expect(await _farm.poolLength()).to.equal(1);
 


### PR DESCRIPTION
Closes #94 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `setMaxSupply` function to allow the owner to set and manage token supply limits.
  
- **Bug Fixes**
  - Enhanced merging functionality to enforce maximum supply constraints, preventing merges that exceed the limit.
  
- **Tests**
  - Added a new test case to verify merge behavior concerning the maximum supply.
  - Updated test cases for the "Farm" contract to skip certain tests affected by an "out of gas" error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->